### PR TITLE
fix: escape the semver range char

### DIFF
--- a/apply_migrations.bat
+++ b/apply_migrations.bat
@@ -1,4 +1,4 @@
-cargo install --no-default-features --features sqlite sqlx-cli@^0.7
+cargo install --no-default-features --features sqlite sqlx-cli@^^0.7
 @if %errorlevel% neq 0 exit /b %errorlevel%
 
 set DATABASE_URL=sqlite:metadata.db 


### PR DESCRIPTION
Windows uses ^ as the escape character, so we escape the escape.