### PR TITLE
Add support for reading User and CI auth credentials from file to support Docker Secrets (Implements #7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,6 +1335,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sqlx",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,8 @@ tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [profile.dev.package.sqlx-macros]
 opt-level = 3


### PR DESCRIPTION
This is my first time writing (and reading) Rust so let me know if there's anything that doesn't suit convention.

The test is a bit invasive since it needed to create files and set env vars, I made it clean itself up though.