### PR TITLE
Allows for depots with non-default stream depths

### DIFF
--- a/migrations/20240725130753_projects_stream_depth.sql
+++ b/migrations/20240725130753_projects_stream_depth.sql
@@ -1,0 +1,5 @@
+UPDATE projects
+    SET
+	      stream = concat(stream, '/', rtrim(rtrim(project, replace(project, rtrim(project, replace(project, '/', '')), '')), '/')),
+	      project = replace(project, rtrim(project, replace(project, '/', '')), '')
+    WHERE project LIKE '%/%';


### PR DESCRIPTION
Fix for issue #12.

- It may not be idiomatic rust.
- The logic could likely be simplified, as the stream name without the depot prefixed is not emitted from the function.
- Tests ensure it works like it used to while supporting bespoke stream depth setups.