### PR TITLE
Update backup and restore command docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,23 @@ to create a `backup.tar` in the current directory:
 
 ```sh
 docker run --rm \
-  --user $(id -u):$(id -g) \
   --volumes-from rugs \
   --mount "type=bind,src=$(pwd),dst=/backup" \
   debian:stable-slim \
-  tar cvf /backup/backup.tar /data
+  tar cvf "/backup/rugs-backup.$(date +"%Y%m%d.%H%M%S").tar" /data
 ```
+
+From within that same directory, you can restore the data with the following command:
+
+```sh
+docker run --rm \
+  --volumes-from rugs \
+  --mount "type=bind,src=$(pwd),dst=/backup" \
+  debian:stable-slim \
+  tar -xvf /backup/rugs-backup.<timestamp>.tar -C /data
+```
+
+Where `<timestamp>` is the timestamp of the backup you want to restore.
 
 This assumes that the container name is `rugs` on your Docker container.
 


### PR DESCRIPTION
I could not restore the backup into the container using the command listed in the README due to permissions issues when attempting to untar the backup.

The commands I have listed in this PR have proven successful for me, allowing me to backup and restore from within the same volume mount with ease.

I have also added a timestamp to the backup command, as I accidently stomped my backup with a bad state because I ran the backup command when I meant to run the restore command.

